### PR TITLE
Changed to TextWriter and stateless design

### DIFF
--- a/APIComparer.Core/APIComparer.Core.csproj
+++ b/APIComparer.Core/APIComparer.Core.csproj
@@ -71,6 +71,7 @@
     <Compile Include="APIUpgradeToMarkdownFormatter.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="BreakingChanges\FieldChangedToNonPublic.cs" />
+    <Compile Include="FormattingInfo.cs" />
     <Compile Include="MatchingMember.cs" />
     <Compile Include="BreakingChanges\MethodChangedToNonPublic.cs" />
     <Compile Include="BreakingChanges\PublicFieldRemoved.cs" />

--- a/APIComparer.Core/FormattingInfo.cs
+++ b/APIComparer.Core/FormattingInfo.cs
@@ -7,8 +7,8 @@ namespace APIComparer
 
         public FormattingInfo(string leftUrl, string rightUrl)
         {
-            this.RightUrl = rightUrl;
-            this.LeftUrl = leftUrl;
+            RightUrl = rightUrl;
+            LeftUrl = leftUrl;
         }
     }
 }

--- a/APIComparer.Core/FormattingInfo.cs
+++ b/APIComparer.Core/FormattingInfo.cs
@@ -1,0 +1,14 @@
+namespace APIComparer
+{
+    public class FormattingInfo
+    {
+        public string RightUrl { get; private set; }
+        public string LeftUrl { get; private set; }
+
+        public FormattingInfo(string leftUrl, string rightUrl)
+        {
+            this.RightUrl = rightUrl;
+            this.LeftUrl = leftUrl;
+        }
+    }
+}

--- a/APIComparer.Tests/APIUpgradeToMarkdownFormatterTests.cs
+++ b/APIComparer.Tests/APIUpgradeToMarkdownFormatterTests.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.IO;
-using System.Text;
-using APIComparer;
 using ApprovalTests;
+using APIComparer;
 using NuGet;
 using NUnit.Framework;
 
@@ -41,10 +40,9 @@ public class APIUpgradeToMarkdownFormatterTests
 
         var diff = engine.CreateDiff(file1, file2);
 
-        var stringBuilder = new StringBuilder();
-        var formatter = new APIUpgradeToMarkdownFormatter(stringBuilder,"","" );
-
-        formatter.WriteOut(diff);
+        var stringBuilder = new StringWriter();
+        var formatter = new APIUpgradeToMarkdownFormatter();
+        formatter.WriteOut(diff, stringBuilder, new FormattingInfo(string.Empty, string.Empty));
 
         Approvals.Verify(stringBuilder.ToString());
     }
@@ -55,10 +53,10 @@ public class APIUpgradeToMarkdownFormatterTests
         var engine = new ComparerEngine();
         var diff = engine.CreateDiff("ExampleV1.dll", "ExampleV2.dll");
 
-        var stringBuilder = new StringBuilder();
-        var formatter = new APIUpgradeToMarkdownFormatter(stringBuilder, "", "");
+        var stringBuilder = new StringWriter();
+        var formatter = new APIUpgradeToMarkdownFormatter();
 
-        formatter.WriteOut(diff);
+        formatter.WriteOut(diff, stringBuilder, new FormattingInfo(string.Empty, string.Empty));
 
         Approvals.Verify(stringBuilder.ToString());
     }

--- a/APIComparer/Program.cs
+++ b/APIComparer/Program.cs
@@ -53,11 +53,6 @@ class Program
 
         var diff = engine.CreateDiff(compareSet.LeftAssemblyGroup, compareSet.RightAssemblyGroup);
 
-        var stringBuilder = new StringBuilder();
-        var formatter = new APIUpgradeToMarkdownFormatter(stringBuilder, "tbd", "tbd");
-        formatter.WriteOut(diff);
-
-
         var breakingChanges = BreakingChangeFinder.Find(diff)
             .ToList();
 
@@ -75,7 +70,16 @@ class Program
             }
 
             var resultFile = string.Format("{0}-{1}..{2}.md", compareSet.Name, compareSet.Versions.LeftVersion, compareSet.Versions.RightVersion);
-            File.WriteAllText(resultFile, stringBuilder.ToString());
+            using (var fileStream = File.OpenWrite(resultFile))
+            using(var into = new StreamWriter(fileStream))
+            {
+                var formatter = new APIUpgradeToMarkdownFormatter();
+                formatter.WriteOut(diff, into, new FormattingInfo("tbd", "tbd"));
+
+                into.Flush();
+                into.Close();
+                fileStream.Close();
+            }
 
             Console.Out.WriteLine(", Full report written to " + resultFile);            
         }


### PR DESCRIPTION
This PR changes the APIUpgradeToMarkdownFormatter to favor a stateless design and rely on TextWriter which allows to either use a StringWriter or a StreamWriter directly