### PR TITLE
Detect and handle source only packages better

### DIFF
--- a/APIComparer.Backend/NuGetDownloader.cs
+++ b/APIComparer.Backend/NuGetDownloader.cs
@@ -39,6 +39,12 @@ namespace APIComparer.Backend
 
             var dirPath = Path.Combine(AzureEnvironment.GetTempPath(), "packages", string.Format("{0}.{1}", package, version), "lib");
 
+            if (!Directory.Exists(dirPath))
+            {
+                // probably source only packages
+                return new List<string>();
+            }
+
             var netVersionDir = Directory.EnumerateDirectories(dirPath)
                 .FirstOrDefault(x => x.EndsWith(target));
 

--- a/APIComparer.Core/APIComparer.Core.csproj
+++ b/APIComparer.Core/APIComparer.Core.csproj
@@ -76,6 +76,7 @@
     <Compile Include="BreakingChanges\MethodChangedToNonPublic.cs" />
     <Compile Include="BreakingChanges\PublicFieldRemoved.cs" />
     <Compile Include="BreakingChanges\PublicMethodRemoved.cs" />
+    <Compile Include="EmptyAssemblyGroup.cs" />
     <Compile Include="TypeDiff.cs" />
     <Compile Include="BreakingChanges\TypeMadeNonPublic.cs" />
     <Compile Include="BreakingChanges\TypeRemoved.cs" />

--- a/APIComparer.Core/APIUpgradeToMarkdownFormatter.cs
+++ b/APIComparer.Core/APIUpgradeToMarkdownFormatter.cs
@@ -76,7 +76,6 @@ namespace APIComparer
                 }
                 writer.WriteLine();
             }
-
         }
 
         void WriteObsoleteFields(TypeDefinition type, TextWriter writer)
@@ -142,31 +141,35 @@ namespace APIComparer
                 writer.WriteLine();
             }
 
-            writer.WriteLine();
-            writer.WriteLine("## The following types have differences.");
-            writer.WriteLine();
-            foreach (var typeDiff in diff.MatchingTypeDiffs)
+            var matchingTypeDiffs = diff.MatchingTypeDiffs.ToList();
+            if (matchingTypeDiffs.Any())
             {
-                if (typeDiff.LeftType.HasObsoleteAttribute())
+                writer.WriteLine();
+                writer.WriteLine("## The following types have differences.");
+                writer.WriteLine();
+                foreach (var typeDiff in diff.MatchingTypeDiffs)
                 {
-                    continue;
-                }
-                if (typeDiff.RightType.HasObsoleteAttribute())
-                {
-                    continue;
-                }
+                    if (typeDiff.LeftType.HasObsoleteAttribute())
+                    {
+                        continue;
+                    }
+                    if (typeDiff.RightType.HasObsoleteAttribute())
+                    {
+                        continue;
+                    }
 
-                if (!typeDiff.LeftType.IsPublic)
-                {
-                    continue;
-                }
-                if (!typeDiff.RightType.IsPublic)
-                {
-                    continue;
-                }
-                if (HasDifferences(typeDiff))
-                {
-                    WriteOut(typeDiff, writer, info);
+                    if (!typeDiff.LeftType.IsPublic)
+                    {
+                        continue;
+                    }
+                    if (!typeDiff.RightType.IsPublic)
+                    {
+                        continue;
+                    }
+                    if (HasDifferences(typeDiff))
+                    {
+                        WriteOut(typeDiff, writer, info);
+                    }
                 }
             }
 

--- a/APIComparer.Core/EmptyAssemblyGroup.cs
+++ b/APIComparer.Core/EmptyAssemblyGroup.cs
@@ -1,0 +1,11 @@
+namespace APIComparer
+{
+    using System.Linq;
+
+    public class EmptyAssemblyGroup : AssemblyGroup
+    {
+        public EmptyAssemblyGroup() : base(Enumerable.Empty<string>())
+        {
+        }
+    }
+}


### PR DESCRIPTION
Detect and handle source only packages better, addresses #17 

Currently this change fixes the bug. But the implication is that you get an empty comparison page. Maybe add a more descriptive result?