### PR TITLE
adding views to support main page with GTM

### DIFF
--- a/APIComparer.Website/APIComparer.Website.csproj
+++ b/APIComparer.Website/APIComparer.Website.csproj
@@ -154,6 +154,8 @@
   <ItemGroup>
     <Content Include="Comparisons\CompareRunning.html" />
     <Content Include="Comparisons\.gitignore" />
+    <Content Include="Views\gtm.html" />
+    <Content Include="Views\home.html" />
     <Content Include="Web.config">
       <SubType>Designer</SubType>
     </Content>
@@ -180,6 +182,7 @@
     <None Include="Properties\PublishProfiles\particular-apicomparer-live.pubxml" />
     <Content Include="Properties\webjobs-list.json" />
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/APIComparer.Website/HomeModule.cs
+++ b/APIComparer.Website/HomeModule.cs
@@ -8,11 +8,10 @@
         public HomeModule()
         {
             Get["/"] = parameters =>
-              {
-                  var fileVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-
-                  return "Hello World - v" + fileVersion;
-              };
+            {
+                var fileVersion = Assembly.GetExecutingAssembly().GetName().Version;
+                return View["home.html", new { Version = fileVersion }];
+            };
         }
     }
 }

--- a/APIComparer.Website/Views/gtm.html
+++ b/APIComparer.Website/Views/gtm.html
@@ -1,0 +1,9 @@
+﻿<!-- Google Tag Manager -->
+<noscript>
+    <iframe src="//www.googletagmanager.com/ns.html?id=GTM-538RR2" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+<script>
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-538RR2');</script>
+<!-- End Google Tag Manager -->

--- a/APIComparer.Website/Views/home.html
+++ b/APIComparer.Website/Views/home.html
@@ -1,0 +1,11 @@
+﻿<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>API Comparer</title>
+</head>
+<body>
+    @Partial['gtm']
+
+    <p>Hello World - v@Model.Version</p>
+</body>
+</html>


### PR DESCRIPTION
Currently we don't track whoever is coming to the main page. 
Added home view to include GTM.

What would be nice is to tie into view engine to return comparisons as views as well.
@ParticularLabs/apicomparer any ideas/thoughts?