### PR TITLE
NuGet Packages Breaking Change Report

### DIFF
--- a/APIComparer.Backend.Tests/APIComparer.Backend.Tests.csproj
+++ b/APIComparer.Backend.Tests/APIComparer.Backend.Tests.csproj
@@ -40,6 +40,10 @@
     <Reference Include="ApprovalUtilities.Net45">
       <HintPath>..\packages\ApprovalUtilities.3.0.8\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
@@ -54,6 +58,10 @@
     </Reference>
     <Reference Include="Mono.Cecil.Rocks, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
@@ -71,6 +79,7 @@
     <Compile Include="APIUpgradeToHtmlFormatterTest.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="CompareLatestPatchTests.cs" />
+    <Compile Include="TopXNugets.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/APIComparer.Backend.Tests/TopXNugets.cs
+++ b/APIComparer.Backend.Tests/TopXNugets.cs
@@ -20,12 +20,13 @@
             ".NETFramework,Version=v4.0"
         };
 
-
-        [Test]
+        /// <summary>
+        /// Ad-hoc report to calculate breaking change statistics for the top 25 .NET NuGet packages. Could be useful on an APIComparer homepage one day.
+        /// </summary>
+        [Test, Explicit]
         public void Should_calculate_stats_for_top_25_packages()
         {
             var packages = repo.Search(String.Empty, Frameworks, false)
-                .Skip(0)
                 .Take(50)
                 .ToList();
 
@@ -35,11 +36,13 @@
             statCollector.Report();
         }
 
-        [Test]
+        /// <summary>
+        /// Ad-hoc report to calculate breaking change statistics for the top 50 NServiceBus packages.
+        /// </summary>
+        [Test, Explicit]
         public void Should_calculate_stats_for_NServiceBus_packages()
         {
             var packages = repo.Search("NServiceBus", Frameworks, false)
-                .Skip(0)
                 .Take(50)
                 .ToList()
                 .Where(p => p.Authors.Contains("NServiceBus Ltd"))

--- a/APIComparer.Backend.Tests/TopXNugets.cs
+++ b/APIComparer.Backend.Tests/TopXNugets.cs
@@ -1,0 +1,115 @@
+﻿namespace APIComparer.Backend.Tests
+{
+    using NuGet;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Reporting;
+    using VersionComparisons;
+
+    [TestFixture]
+    public class TopXNugets
+    {
+        IPackageRepository repo;
+        IPackageManager packageManager;
+
+        public TopXNugets()
+        {
+            repo = PackageRepositoryFactory.Default.CreateRepository("https://packages.nuget.org/api/v2");
+            packageManager = new PackageManager(repo, "packages");
+        }
+
+        [Test]
+        public void Should_calculate_stats_for_top_10_packages()
+        {
+            var frameworks = new []
+            {
+                ".NETFramework,Version=v4.5",
+                ".NETFramework,Version=v4.0"
+            };
+
+            var packages = repo.Search(String.Empty, frameworks, false)
+                .Skip(0)
+                .Take(25)
+                .ToList();
+
+            var output = new List<PackageResults>();
+
+            foreach (var pkg in packages)
+            {
+                Console.WriteLine($"Processing package {pkg.Id}...");
+
+                var dotNetRefs = pkg.AssemblyReferences.OfType<PhysicalPackageAssemblyReference>()
+                    .Where(pkgRef => frameworks.Contains(pkgRef.TargetFramework?.FullName))
+                    .ToList();
+
+                if (!dotNetRefs.Any())
+                {
+                    Console.WriteLine("    Not a .NET package");
+                    continue;
+                }
+
+                var versions = repo.FindPackagesById(pkg.Id)
+                    .FilterByPrerelease(false)
+                    .OrderByDescending(p => p.Version)
+                    .ToList();
+
+                var latest = versions.First();
+                var minor = versions.Last(p => p.Version.Version.Major == latest.Version.Version.Major && p.Version.Version.Minor == latest.Version.Version.Minor);
+                var major = versions.Last(p => p.Version.Version.Major == latest.Version.Version.Major);
+
+                packageManager.InstallPackage(pkg.Id, major.Version, true, false);
+                packageManager.InstallPackage(pkg.Id, minor.Version, true, false);
+                packageManager.InstallPackage(pkg.Id, latest.Version, true, false);
+
+                var minorDiff = Diff(pkg, minor.Version, latest.Version);
+                var majorDiff = Diff(pkg, major.Version, latest.Version);
+
+                output.Add(new PackageResults()
+                {
+                    Id = pkg.Id,
+                    CurrentVersion = latest.Version,
+                    MajorVersion = major.Version,
+                    MinorVersion = minor.Version,
+                    MinorDiff = minorDiff,
+                    MajorDiff = majorDiff
+                });
+
+                if (output.Count == 10)
+                    break;
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("== Output ==");
+            foreach (var res in output)
+                Console.WriteLine($"{res.Id} {res.MajorVersion} {res.MinorVersion} {res.CurrentVersion}");
+        }
+
+        internal class PackageResults
+        {
+            public string Id { get; set; }
+            public SemanticVersion CurrentVersion { get; set; }
+            public SemanticVersion MinorVersion { get; set; }
+            public SemanticVersion MajorVersion { get; set; }
+            public object MinorDiff { get; set; }
+            public object MajorDiff { get; set; }
+        }
+
+        private object Diff(IPackage pkg, SemanticVersion left, SemanticVersion right)
+        {
+            var creator = new CompareSetCreator();
+            var differ = new CompareSetDiffer();
+
+            var packageDescription = new PackageDescription
+            {
+                PackageId = pkg.Id,
+                Versions = new VersionPair(left.ToString(), right.ToString())
+            };
+
+            var compareSets = creator.Create(packageDescription);
+            var diffedCompareSets = differ.Diff(compareSets);
+            return ViewModelBuilder.Build(packageDescription, diffedCompareSets);
+        }
+    }
+}

--- a/APIComparer.Backend.Tests/TopXNugets.cs
+++ b/APIComparer.Backend.Tests/TopXNugets.cs
@@ -5,156 +5,208 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text.RegularExpressions;
     using Reporting;
     using VersionComparisons;
 
     [TestFixture]
     public class TopXNugets
     {
-        IPackageRepository repo;
-        IPackageManager packageManager;
-        readonly string[] frameworks;
+        IPackageRepository repo = PackageRepositoryFactory.Default.CreateRepository("https://packages.nuget.org/api/v2");
 
-        public TopXNugets()
+        internal static string[] Frameworks =
         {
-            repo = PackageRepositoryFactory.Default.CreateRepository("https://packages.nuget.org/api/v2");
-            packageManager = new PackageManager(repo, "packages");
+            ".NETFramework,Version=v4.5",
+            ".NETFramework,Version=v4.0"
+        };
 
-            frameworks = new[]
-            {
-                ".NETFramework,Version=v4.5",
-                ".NETFramework,Version=v4.0"
-            };
-        }
 
         [Test]
         public void Should_calculate_stats_for_top_25_packages()
         {
-            var packages = repo.Search(String.Empty, frameworks, false)
+            var packages = repo.Search(String.Empty, Frameworks, false)
                 .Skip(0)
                 .Take(50)
                 .ToList();
 
-            var output = new List<PackageResults>();
+            var statCollector = new StatsCollector(repo, packages);
+            statCollector.Limit = 25;
 
-            foreach (var pkg in packages)
-            {
-                Console.WriteLine($"Processing package {pkg.Id}...");
-
-                if (!HasDotNetAssemblies(pkg))
-                {
-                    Console.WriteLine("    Not a .NET package");
-                    continue;
-                }
-
-                var versions = repo.FindPackagesById(pkg.Id)
-                    .FilterByPrerelease(false)
-                    .OrderByDescending(p => p.Version)
-                    .ToList();
-
-                var latest = versions.First();
-                var minor = versions.Last(p => p.Version.Version.Major == latest.Version.Version.Major && p.Version.Version.Minor == latest.Version.Version.Minor);
-                var major = versions.Last(p => p.Version.Version.Major == latest.Version.Version.Major);
-
-                if (!HasDotNetAssemblies(minor) && !HasDotNetAssemblies(major))
-                {
-                    Console.WriteLine("    Lastest major/minor not .NET packages");
-                    continue;
-                }
-
-                packageManager.InstallPackage(pkg.Id, major.Version, true, false);
-                packageManager.InstallPackage(pkg.Id, minor.Version, true, false);
-                packageManager.InstallPackage(pkg.Id, latest.Version, true, false);
-
-                var pkgResult = new PackageResults()
-                {
-                    Id = pkg.Id,
-                    CurrentVersion = latest.Version,
-                    Major = new VersionReport(pkg.Id, latest.Version, major.Version),
-                    Minor = new VersionReport(pkg.Id, latest.Version, minor.Version)
-                };
-
-                if (HasDotNetAssemblies(minor))
-                    pkgResult.Minor.Diff = Diff(pkg, minor.Version, latest.Version);
-                if (HasDotNetAssemblies(major))
-                    pkgResult.Major.Diff = Diff(pkg, major.Version, latest.Version);
-
-                output.Add(pkgResult);
-
-                if (output.Count == 25)
-                    break;
-            }
-
-            Console.WriteLine();
-            Console.WriteLine("| Package Name | Current Version | Latest Minor | Latest Major |");
-            Console.WriteLine("| --------------|:---------------:|:------------------:|:-------------------:|");
-            foreach (var res in output)
-            {
-                Console.WriteLine($"| {res.Id} | {res.CurrentVersion} | {res.Minor.Report()} | {res.Major.Report()} |");
-            }
+            statCollector.Report();
         }
 
-        internal class PackageResults
+        [Test]
+        public void Should_calculate_stats_for_NServiceBus_packages()
         {
-            public string Id { get; set; }
-            public SemanticVersion CurrentVersion { get; set; }
-            public VersionReport Minor { get; set; }
-            public VersionReport Major { get; set; }
-        }
+            var packages = repo.Search("NServiceBus", Frameworks, false)
+                .Skip(0)
+                .Take(50)
+                .ToList()
+                .Where(p => p.Authors.Contains("NServiceBus Ltd"))
+                .OrderByDescending(p => p.DownloadCount)
+                .ToList();
 
-        internal class VersionReport
-        {
-            public string PackageId { get; }
-            public SemanticVersion Version { get; }
-            public SemanticVersion Current { get; }
-            public TargetReport Diff { get; set; }
-
-            public VersionReport(string packageId, SemanticVersion current, SemanticVersion version)
+            var statCollector = new StatsCollector(repo, packages);
+            statCollector.Filter = "^NServiceBus";
+            statCollector.SkipPackages = new[]
             {
-                PackageId = packageId;
-                Current = current;
-                Version = version;
-            }
-
-            public string Report()
-            {
-                if (Diff == null)
-                    return $"<span title=\"Comparing {Version}...{Current}\">Not .NET</span>";
-
-                return $"<a title=\"Comparing {Version}...{Current}\" href=\"http://apicomparer.particular.net/Compare/{PackageId}/{Version}...{Current}\">{Diff.BreakingChanges}</a>";
-            }
-        }
-
-        TargetReport Diff(IPackage pkg, SemanticVersion left, SemanticVersion right)
-        {
-            var creator = new CompareSetCreator();
-            var differ = new CompareSetDiffer();
-
-            var packageDescription = new PackageDescription
-            {
-                PackageId = pkg.Id,
-                Versions = new VersionPair(left.ToString(), right.ToString())
+                "NServiceBus.AcceptanceTesting",
+                "NServiceBus.RavenDB",
+                "NServiceBus.Wire"
             };
 
-            var compareSets = creator.Create(packageDescription);
-            var diffedCompareSets = differ.Diff(compareSets);
-            var vm = ViewModelBuilder.Build(packageDescription, diffedCompareSets);
-
-            foreach (var framework in frameworks)
-            {
-                var target = vm.targets.FirstOrDefault(trg => trg.Name == framework);
-                if (target != null)
-                    return target;
-            }
-
-            return null;
+            statCollector.Report();
         }
 
-        bool HasDotNetAssemblies(IPackage pkg)
+        public class StatsCollector
         {
-            return pkg.AssemblyReferences
-                .OfType<PhysicalPackageAssemblyReference>()
-                .Any(pkgRef => frameworks.Contains(pkgRef.TargetFramework?.FullName));
+            IPackageRepository repo;
+            IPackageManager packageManager;
+            IEnumerable<IPackage> packages; 
+
+            public int Limit { get; set; }
+            public IEnumerable<string> SkipPackages { get; set; }
+            public string Filter { get; set; }
+
+            public StatsCollector(IPackageRepository repo, IEnumerable<IPackage> packages)
+            {
+                this.repo = repo;
+                this.packages = packages;
+                packageManager = new PackageManager(repo, "packages");
+
+                SkipPackages = Enumerable.Empty<string>();
+                Filter = ".*";
+            }
+
+            public void Report()
+            {
+                var output = new List<PackageResults>();
+
+                foreach (var pkg in packages)
+                {
+                    Console.WriteLine($"Processing package {pkg.Id}...");
+
+                    if (SkipPackages.Contains(pkg.Id) || !Regex.IsMatch(pkg.Id, Filter))
+                    {
+                        Console.WriteLine("   Skipping");
+                        continue;
+                    }
+
+                    if (!HasDotNetAssemblies(pkg))
+                    {
+                        Console.WriteLine("    Not a .NET package");
+                        continue;
+                    }
+
+                    var versions = repo.FindPackagesById(pkg.Id)
+                        .FilterByPrerelease(false)
+                        .OrderByDescending(p => p.Version)
+                        .ToList();
+
+                    var latest = versions.First();
+                    var minor = versions.Last(p => p.Version.Version.Major == latest.Version.Version.Major && p.Version.Version.Minor == latest.Version.Version.Minor);
+                    var major = versions.Last(p => p.Version.Version.Major == latest.Version.Version.Major);
+
+                    if (!HasDotNetAssemblies(minor) && !HasDotNetAssemblies(major))
+                    {
+                        Console.WriteLine("    Lastest major/minor not .NET packages");
+                        continue;
+                    }
+
+                    packageManager.InstallPackage(pkg.Id, major.Version, true, false);
+                    packageManager.InstallPackage(pkg.Id, minor.Version, true, false);
+                    packageManager.InstallPackage(pkg.Id, latest.Version, true, false);
+
+                    var pkgResult = new PackageResults()
+                    {
+                        Id = pkg.Id,
+                        CurrentVersion = latest.Version,
+                        Major = new VersionReport(pkg.Id, latest.Version, major.Version),
+                        Minor = new VersionReport(pkg.Id, latest.Version, minor.Version)
+                    };
+
+                    if (HasDotNetAssemblies(minor))
+                        pkgResult.Minor.Diff = Diff(pkg, minor.Version, latest.Version);
+                    if (HasDotNetAssemblies(major))
+                        pkgResult.Major.Diff = Diff(pkg, major.Version, latest.Version);
+
+                    output.Add(pkgResult);
+
+                    if (Limit > 0 && output.Count >= Limit)
+                        break;
+                }
+
+                Console.WriteLine();
+                Console.WriteLine("| Package Name | Current Version | Latest Minor | Latest Major |");
+                Console.WriteLine("| --------------|:---------------:|:------------------:|:-------------------:|");
+                foreach (var res in output)
+                {
+                    Console.WriteLine($"| {res.Id} | {res.CurrentVersion} | {res.Minor.Report()} | {res.Major.Report()} |");
+                }
+            }
+
+            internal class PackageResults
+            {
+                public string Id { get; set; }
+                public SemanticVersion CurrentVersion { get; set; }
+                public VersionReport Minor { get; set; }
+                public VersionReport Major { get; set; }
+            }
+
+            internal class VersionReport
+            {
+                public string PackageId { get; }
+                public SemanticVersion Version { get; }
+                public SemanticVersion Current { get; }
+                public TargetReport Diff { get; set; }
+
+                public VersionReport(string packageId, SemanticVersion current, SemanticVersion version)
+                {
+                    PackageId = packageId;
+                    Current = current;
+                    Version = version;
+                }
+
+                public string Report()
+                {
+                    if (Diff == null)
+                        return $"<span title=\"Comparing {Version}...{Current}\">Not .NET</span>";
+
+                    return $"<a title=\"Comparing {Version}...{Current}\" href=\"http://apicomparer.particular.net/Compare/{PackageId}/{Version}...{Current}\">{Diff.BreakingChanges}</a>";
+                }
+            }
+
+            TargetReport Diff(IPackage pkg, SemanticVersion left, SemanticVersion right)
+            {
+                var creator = new CompareSetCreator();
+                var differ = new CompareSetDiffer();
+
+                var packageDescription = new PackageDescription
+                {
+                    PackageId = pkg.Id,
+                    Versions = new VersionPair(left.ToString(), right.ToString())
+                };
+
+                var compareSets = creator.Create(packageDescription);
+                var diffedCompareSets = differ.Diff(compareSets);
+                var vm = ViewModelBuilder.Build(packageDescription, diffedCompareSets);
+
+                foreach (var framework in TopXNugets.Frameworks)
+                {
+                    var target = vm.targets.FirstOrDefault(trg => trg.Name == framework);
+                    if (target != null)
+                        return target;
+                }
+
+                return null;
+            }
+
+            bool HasDotNetAssemblies(IPackage pkg)
+            {
+                return pkg.AssemblyReferences
+                    .OfType<PhysicalPackageAssemblyReference>()
+                    .Any(pkgRef => TopXNugets.Frameworks.Contains(pkgRef.TargetFramework?.FullName));
+            }
         }
     }
 }

--- a/APIComparer.Backend.Tests/packages.config
+++ b/APIComparer.Backend.Tests/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="ApprovalTests" version="3.0.8" targetFramework="net45" />
   <package id="ApprovalUtilities" version="3.0.8" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/APIComparer.Backend/APIComparer.Backend.csproj
+++ b/APIComparer.Backend/APIComparer.Backend.csproj
@@ -140,6 +140,11 @@
     <Compile Include="Reporting\Helpers.Html.cs" />
     <Compile Include="Reporting\IFormatter.cs" />
     <Compile Include="Reporting\ViewModelBuilder.cs" />
+    <Compile Include="Reporting\ViewModel\APIComparison.cs" />
+    <Compile Include="Reporting\ViewModel\ObsoletedItem.cs" />
+    <Compile Include="Reporting\ViewModel\RemovedItem.cs" />
+    <Compile Include="Reporting\ViewModel\TargetReport.cs" />
+    <Compile Include="Reporting\ViewModel\TypeDifferencesReport.cs" />
     <Compile Include="Shared\AzureEnvironment.cs" />
     <Compile Include="Shared\ConfigureAuditQueue.cs" />
     <Compile Include="Shared\ConfigureAzureSubscriptionStorage.cs" />

--- a/APIComparer.Backend/Reporting/ViewModel/APIComparison.cs
+++ b/APIComparer.Backend/Reporting/ViewModel/APIComparison.cs
@@ -1,0 +1,9 @@
+﻿namespace APIComparer.Backend.Reporting
+{
+    using System.Collections.Generic;
+
+    public class APIComparison
+    {
+        public IEnumerable<TargetReport> targets { get; set; }
+    }
+}

--- a/APIComparer.Backend/Reporting/ViewModel/ObsoletedItem.cs
+++ b/APIComparer.Backend/Reporting/ViewModel/ObsoletedItem.cs
@@ -1,0 +1,8 @@
+﻿namespace APIComparer.Backend.Reporting
+{
+    public class ObsoletedItem
+    {
+        public string name { get; set; }
+        public string obsolete { get; set; }
+    }
+}

--- a/APIComparer.Backend/Reporting/ViewModel/RemovedItem.cs
+++ b/APIComparer.Backend/Reporting/ViewModel/RemovedItem.cs
@@ -1,0 +1,7 @@
+﻿namespace APIComparer.Backend.Reporting
+{
+    public class RemovedItem
+    {
+        public string name { get; set; }
+    }
+}

--- a/APIComparer.Backend/Reporting/ViewModel/TargetReport.cs
+++ b/APIComparer.Backend/Reporting/ViewModel/TargetReport.cs
@@ -1,6 +1,7 @@
 ﻿namespace APIComparer.Backend.Reporting
 {
     using System.Collections.Generic;
+    using System.Linq;
 
     public class TargetReport
     {
@@ -15,5 +16,15 @@
         public bool hasTypeDifferences { get; set; }
         public IEnumerable<TypeDifferencesReport> typeDifferences { get; set; }
         public bool hasChanges { get; set; }
+
+        public int BreakingChanges
+        {
+            get
+            {
+                return removedPublicTypes.Count()
+                       + typesMadeInternal.Count()
+                       + typeDifferences.Sum(td => td.BreakingChanges);
+            }
+        }
     }
 }

--- a/APIComparer.Backend/Reporting/ViewModel/TargetReport.cs
+++ b/APIComparer.Backend/Reporting/ViewModel/TargetReport.cs
@@ -1,0 +1,19 @@
+﻿namespace APIComparer.Backend.Reporting
+{
+    using System.Collections.Generic;
+
+    public class TargetReport
+    {
+        public string Name { get; set; }
+        public string ShortName { get; set; }
+        public string ComparedTo { get; set; }
+        public bool noLongerSupported { get; set; }
+        public bool hasRemovedPublicTypes { get; set; }
+        public IEnumerable<RemovedItem> removedPublicTypes { get; set; }
+        public bool hasTypesMadeInternal { get; set; }
+        public IEnumerable<RemovedItem> typesMadeInternal { get; set; }
+        public bool hasTypeDifferences { get; set; }
+        public IEnumerable<TypeDifferencesReport> typeDifferences { get; set; }
+        public bool hasChanges { get; set; }
+    }
+}

--- a/APIComparer.Backend/Reporting/ViewModel/TypeDifferencesReport.cs
+++ b/APIComparer.Backend/Reporting/ViewModel/TypeDifferencesReport.cs
@@ -1,0 +1,29 @@
+﻿namespace APIComparer.Backend.Reporting
+{
+    using System.Collections.Generic;
+
+    public class TypeDifferencesReport
+    {
+        public string name { get; set; }
+        public bool hasBeenObsoleted { get; set; }
+        public string obsoleteMessage { get; set; }
+
+        public bool hasFieldsChangedToNonPublic { get; set; }
+        public IEnumerable<RemovedItem> fieldsChangedToNonPublic { get; set; }
+
+        public bool hasFieldsObsoleted { get; set; }
+        public IEnumerable<ObsoletedItem> fieldsObsoleted { get; set; }
+
+        public bool hasFieldsRemoved { get; set; }
+        public IEnumerable<RemovedItem> fieldsRemoved { get; set; }
+
+        public bool hasMethodsChangedToNonPublic { get; set; }
+        public IEnumerable<RemovedItem> methodsChangedToNonPublic { get; set; }
+
+        public bool hasMethodsRemoved { get; set; }
+        public IEnumerable<RemovedItem> methodsRemoved { get; set; }
+
+        public bool hasMethodsObsoleted { get; set; }
+        public IEnumerable<ObsoletedItem> methodsObsoleted { get; set; }
+    }
+}

--- a/APIComparer.Backend/Reporting/ViewModel/TypeDifferencesReport.cs
+++ b/APIComparer.Backend/Reporting/ViewModel/TypeDifferencesReport.cs
@@ -1,6 +1,7 @@
 ﻿namespace APIComparer.Backend.Reporting
 {
     using System.Collections.Generic;
+    using System.Linq;
 
     public class TypeDifferencesReport
     {
@@ -25,5 +26,16 @@
 
         public bool hasMethodsObsoleted { get; set; }
         public IEnumerable<ObsoletedItem> methodsObsoleted { get; set; }
+
+        public int BreakingChanges
+        {
+            get
+            {
+                return fieldsChangedToNonPublic.Count()
+                       + fieldsRemoved.Count()
+                       + methodsChangedToNonPublic.Count()
+                       + methodsRemoved.Count();
+            }
+        }
     }
 }


### PR DESCRIPTION
I'm querying NuGet packages and then generating a report to show breaking changes from the corresponding minor and major versions. So for example if the current version of something is 6.2.3, it would discover breaking changes from 6.20...6.2.3 and 6.0.0...6.2.3.

One test does this for the top 25 popular NuGet packages (that have .NET sources) and the other does it for our NServiceBus packages.

I needed to change the ViewModel for the API compare to static types so I could use them more easily from other code, and expand them to count breaking changes, but functionality should be unchanged. I also had to take a dependency on NuGet.Core in the Backend Tests.

@ParticularLabs/apicomparer please review.