### PR TITLE
naive implementation of response when package(s) not available.

### DIFF
--- a/APIComparer.Backend/CompareSetReporter.cs
+++ b/APIComparer.Backend/CompareSetReporter.cs
@@ -25,6 +25,13 @@ namespace APIComparer.Backend
             RemoveTemporaryWorkFiles(resultPath);
         }
 
+        public void ReportFailure(PackageDescription packageDescription, Exception exception)
+        {
+            var resultPath = DetermineAndCreateResultPathIfNotExistant(packageDescription);
+            File.WriteAllText(resultPath, $"{packageDescription.PackageId} comparison between {packageDescription.Versions.LeftVersion} and {packageDescription.Versions.RightVersion} has failed with the following error: {exception.Message}");
+            RemoveTemporaryWorkFiles(resultPath);
+        }
+
         static string DetermineAndCreateResultPathIfNotExistant(PackageDescription description)
         {
             var resultFile = $"{description.PackageId}-{description.Versions.LeftVersion}...{description.Versions.RightVersion}.html";


### PR DESCRIPTION
Addresses #60 

Request that would result in exception
`http://localhost:2321/Compare/NHibernate/3.0.1.4000...4.0.4.4000`

Now would return the following:
`NHibernate comparison between 3.0.1.4000 and 4.0.4.4000 has failed with the following error: System.InvalidOperationException: Unable to find version '3.0.1.4000' of package 'NHibernate'. at NuGet.PackageRepositoryHelper.ResolvePackage(IPackageRepository sourceRepository, IPackageRepository localRepository, IPackageConstraintProvider constraintProvider, String packageId, SemanticVersion version, Boolean allowPrereleaseVersions) at NuGet.PackageRepositoryHelper.ResolvePackage(IPackageRepository sourceRepository, IP...`

@andreasohlund would this work?
