### PR TITLE
Handle exceptions via stderr & exit code

### DIFF
--- a/APIComparer/APIComparer.csproj
+++ b/APIComparer/APIComparer.csproj
@@ -74,6 +74,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApiComparerArgumentException.cs" />
+    <Compile Include="ExitCode.cs" />
     <Compile Include="NuGetBrowser.cs" />
     <Compile Include="VersionComparisons\CompareAgainstFirstReleaseStrategy.cs" />
     <Compile Include="VersionComparisons\CompareAgainstNextReleaseStrategy.cs" />

--- a/APIComparer/ApiComparerArgumentException.cs
+++ b/APIComparer/ApiComparerArgumentException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+public class ApiComparerArgumentException : Exception
+{
+    public ApiComparerArgumentException(string message) : base(message)
+    {
+    }
+}

--- a/APIComparer/ExitCode.cs
+++ b/APIComparer/ExitCode.cs
@@ -1,0 +1,7 @@
+internal struct ExitCode
+{
+    internal const int Ok = 0;
+    internal const int GenericError = 1;
+    internal const int InvalidArgument = 128;
+    internal const int BreakingChange = 129;
+}


### PR DESCRIPTION
Currently when you run the console ApiComparer without arguments it'll crash unhandled
![image](https://cloud.githubusercontent.com/assets/1647294/14876987/a402f2a8-0d19-11e6-917b-60009c9c8520.png)
```
Unhandled Exception: System.Exception: No target assemblies specified, please use --source {asm1};{asm2}...
   at Program.GetExplicitAssembliesToCompare(String[] args) in \APIComparer\APIComparer\Program.cs:line 176
   at Program.Main(String[] args) in \APIComparer\APIComparer\Program.cs:line 30
```

What's proposed in this is PR is
* Refactored so exceptions
  * Are handled
  * Logged to stderr
  * Known / Unknown reflected on exit code
* Also breaking change reported via exit code


Post this change program crash won't occur, instead "known" exceptions will result in error message being printed to stderr and exit code changed.
```
Argument exception: No target assemblies specified, please use --source {asm1};{asm2}...
```
And unhandled exceptions will log exception with stacktrace to stderr and change exit code example:
```
Unhandled exception: System.IO.FileNotFoundException: Could not load file or assembly 'dll' or one of its dependencies. The system cannot find the file specified.
File name: 'dll' ---> System.IO.FileNotFoundException: The system cannot find the file specified. (Exception from HRESULT: 0x80070002)
   at System.Reflection.AssemblyName.nGetFileInformation(String s)
   at System.Reflection.AssemblyName.GetAssemblyName(String assemblyFile)
   at APIComparer.ComparerEngine.IsManagedAssembly(String assemblyPath) in \APIComparer\APIComparer.Core\ComparerEngine.cs:line 61
   at APIComparer.ComparerEngine.<ReadTypes>b__3_0(String assembly) in \APIComparer\APIComparer.Core\ComparerEngine.cs:line 42
   at System.Linq.Enumerable.WhereListIterator`1.MoveNext()
   at System.Linq.Enumerable.<SelectManyIterator>d__16`2.MoveNext()
   at APIComparer.CecilExtensions.RealTypes(IEnumerable`1 types) in \APIComparer\APIComparer.Core\CecilExtensions.cs:line 159
   at APIComparer.ComparerEngine.CreateDiff(IEnumerable`1 left, IEnumerable`1 right) in \APIComparer\APIComparer.Core\ComparerEngine.cs:line 77
   at APIComparer.ComparerEngine.CreateDiff(AssemblyGroup leftAssemblyGroup, AssemblyGroup rightAssemblyGroup) in \APIComparer\APIComparer.Core\ComparerEngine.cs:line 31
   at Program.Compare(CompareSet compareSet, Boolean showAllVersions) in \APIComparer\APIComparer\Program.cs:line 65
   at Program.<>c__DisplayClass0_0.<Main>b__0(CompareSet set) in \APIComparer\APIComparer\Program.cs:line 38
   at System.Linq.Enumerable.All[TSource](IEnumerable`1 source, Func`2 predicate)
   at Program.Main(String[] args) in \APIComparer\APIComparer\Program.cs:line 38`
```

Also did a small optimization, previously `--show-failed-only` was parsed each iteration, it's now parsed only once.
