### PR TITLE
Added support for detecting public enum fields whose value has changed.

### DIFF
--- a/APIComparer.Core/APIComparer.Core.csproj
+++ b/APIComparer.Core/APIComparer.Core.csproj
@@ -65,6 +65,7 @@
     <Compile Include="AssemblyGroup.cs" />
     <Compile Include="BreakingChanges\BreakingChange.cs" />
     <Compile Include="BreakingChanges\BreakingChangeFinder.cs" />
+    <Compile Include="BreakingChanges\EnumFieldValueChanged.cs" />
     <Compile Include="CecilExtensions.cs" />
     <Compile Include="ChangedType.cs" />
     <Compile Include="ObsoleteInfo.cs" />

--- a/APIComparer.Core/APIUpgradeToMarkdownFormatter.cs
+++ b/APIComparer.Core/APIUpgradeToMarkdownFormatter.cs
@@ -104,12 +104,33 @@ namespace APIComparer
 
                 writer.WriteLine();
             }
+
+            var changedEnumMembers = changedType.ChangedEnumMembers;
+
+            if (changedEnumMembers.Any())
+            {
+                writer.WriteLine($"{new string('#', headingSize + 1)} Changed Enum Members");
+                writer.WriteLine();
+
+                foreach (var typeChange in changedEnumMembers)
+                {
+                    WriteRemovedMember(writer, typeChange);
+                }
+
+                writer.WriteLine();
+            }
         }
 
         static void WriteRemovedMember(TextWriter writer, ChangedType.RemovedMember removedMember)
         {
             var upgradeInstructions = removedMember.UpgradeInstructions ?? "No upgrade instructions provided.";
             writer.WriteLine($"* `{removedMember.Name}` - {upgradeInstructions}");
+        }
+
+        static void WriteRemovedMember(TextWriter writer, ChangedType.ChangedEnumMember changedMember)
+        {
+            var upgradeInstructions = changedMember.UpgradeInstructions ?? "No upgrade instructions provided.";
+            writer.WriteLine($"* `{changedMember.Name}` - {upgradeInstructions}");
         }
     }
 }

--- a/APIComparer.Core/ApiChanges.cs
+++ b/APIComparer.Core/ApiChanges.cs
@@ -113,12 +113,12 @@ namespace APIComparer
                 .ToList();
 
             var changedEnumMembers = typesWithMemberDiffs
-                .SelectMany(td => td.EnumFieldsWithChangedValue().Where(t => t.Left.IsPublic && !t.Left.IsObsoleteWithError()))
+                .SelectMany(td => td.EnumFieldsWithChangedValue().Where(t => t.IsPublic && !t.IsObsoleteWithError()))
                 .Select(fd => new
                 {
                     Version = "Current",
-                    Type = fd.Left.DeclaringType,
-                    ChangedMember = new ChangedType.ChangedEnumMember(fd.Left, fd.Right)
+                    Type = fd.DeclaringType,
+                    ChangedMember = new ChangedType.ChangedEnumMember(fd)
                 })
                 .ToList();
 

--- a/APIComparer.Core/ApiChanges.cs
+++ b/APIComparer.Core/ApiChanges.cs
@@ -112,6 +112,22 @@ namespace APIComparer
                 })
                 .ToList();
 
+            var changedEnumMembers = typesWithMemberDiffs
+                .SelectMany(td => td.EnumFieldsWithChangedValue().Where(t => t.Left.IsPublic && !t.Left.IsObsoleteWithError()))
+                .Select(fd => new
+                {
+                    Version = "Current",
+                    Type = fd.Left.DeclaringType,
+                    ChangedMember = new ChangedType.ChangedEnumMember(fd.Left, fd.Right)
+                })
+                .ToList();
+
+            var changedEnumMemberChanges = changedEnumMembers
+                .Where(ce => ce.Version == "Current")
+                .GroupBy(ce => ce.Type)
+                .Select(g => new ChangedType(g.Key, null, g.Select(e => e.ChangedMember).ToList()))
+                .ToList();
+
             var removedMembers = removedFields
                 .Concat(removedMethods)
                 .Concat(methodsNotAvailableForUse)
@@ -124,10 +140,9 @@ namespace APIComparer
                 .Select(g => new ChangedType(g.Key, g.Select(r => r.RemovedMember).ToList()))
                 .ToList();
 
-
             var result = new List<ApiChanges>
             {
-                new ApiChanges("Current", removedTypes, changedTypesInCurrentVersion)
+                new ApiChanges("Current", removedTypes, changedTypesInCurrentVersion.Concat(changedEnumMemberChanges).ToList())
             };
 
             var futureChanges = removedMembers

--- a/APIComparer.Core/BreakingChanges/BreakingChangeFinder.cs
+++ b/APIComparer.Core/BreakingChanges/BreakingChangeFinder.cs
@@ -38,7 +38,11 @@ namespace APIComparer.BreakingChanges
                 breakingChanges.AddRange(typeDiff.PublicMethodsRemoved().Select(method => new PublicMethodRemoved(typeDiff.LeftType, method)));
                 breakingChanges.AddRange(typeDiff.FieldsChangedToNonPublic().Select(field => new FieldChangedToNonPublic(typeDiff.LeftType, field.Left)));
                 breakingChanges.AddRange(typeDiff.MethodsChangedToNonPublic().Select(method => new MethodChangedToNonPublic(typeDiff.LeftType, method.Left)));
-         
+
+                if (typeDiff.LeftType.IsEnum)
+                {
+                    breakingChanges.AddRange(typeDiff.EnumFieldsWithChangedValue().Select(field => new EnumFieldValueChanged(typeDiff.LeftType, field.Left, field.Right)));
+                }
             }
 
             return breakingChanges;

--- a/APIComparer.Core/BreakingChanges/BreakingChangeFinder.cs
+++ b/APIComparer.Core/BreakingChanges/BreakingChangeFinder.cs
@@ -41,7 +41,7 @@ namespace APIComparer.BreakingChanges
 
                 if (typeDiff.LeftType.IsEnum)
                 {
-                    breakingChanges.AddRange(typeDiff.EnumFieldsWithChangedValue().Select(field => new EnumFieldValueChanged(typeDiff.LeftType, field.Left, field.Right)));
+                    breakingChanges.AddRange(typeDiff.EnumFieldsWithChangedValue().Select(field => new EnumFieldValueChanged(typeDiff.LeftType, field)));
                 }
             }
 

--- a/APIComparer.Core/BreakingChanges/EnumFieldValueChanged.cs
+++ b/APIComparer.Core/BreakingChanges/EnumFieldValueChanged.cs
@@ -1,0 +1,20 @@
+﻿using Mono.Cecil;
+
+namespace APIComparer.BreakingChanges
+{
+    public class EnumFieldValueChanged : BreakingChange
+    {
+        public EnumFieldValueChanged(TypeDefinition typeDefinition, FieldDefinition leftField, FieldDefinition rightField)
+        {
+            this.typeDefinition = typeDefinition;
+            this.leftField = leftField;
+            this.rightField = rightField;
+        }
+
+        public override string Reason => $"Member {leftField.Name} of type {typeDefinition} value has been changed from {leftField.Constant} to {rightField.Constant}";
+
+        FieldDefinition leftField;
+        FieldDefinition rightField;
+        TypeDefinition typeDefinition;
+    }
+}

--- a/APIComparer.Core/BreakingChanges/EnumFieldValueChanged.cs
+++ b/APIComparer.Core/BreakingChanges/EnumFieldValueChanged.cs
@@ -4,17 +4,15 @@ namespace APIComparer.BreakingChanges
 {
     public class EnumFieldValueChanged : BreakingChange
     {
-        public EnumFieldValueChanged(TypeDefinition typeDefinition, FieldDefinition leftField, FieldDefinition rightField)
+        public EnumFieldValueChanged(TypeDefinition typeDefinition, FieldDefinition field)
         {
             this.typeDefinition = typeDefinition;
-            this.leftField = leftField;
-            this.rightField = rightField;
+            this.field = field;
         }
 
-        public override string Reason => $"Member {leftField.Name} of type {typeDefinition} value has been changed from {leftField.Constant} to {rightField.Constant}";
+        public override string Reason => $"Member {field.Name} of Enum type {typeDefinition} value has been changed";
 
-        FieldDefinition leftField;
-        FieldDefinition rightField;
+        FieldDefinition field;
         TypeDefinition typeDefinition;
     }
 }

--- a/APIComparer.Core/CecilExtensions.cs
+++ b/APIComparer.Core/CecilExtensions.cs
@@ -270,6 +270,7 @@
                 typeDiff.MethodsChangedToNonPublic().Any() ||
                 typeDiff.PublicMethodsObsoleted().Any() ||
                 typeDiff.PublicFieldsObsoleted().Any() ||
+                typeDiff.EnumFieldsWithChangedValue().Any() ||
                 typeDiff.TypeObsoleted();
         }
     }

--- a/APIComparer.Core/ChangedType.cs
+++ b/APIComparer.Core/ChangedType.cs
@@ -112,14 +112,13 @@
 
         public class ChangedEnumMember
         {
-            public ChangedEnumMember(FieldDefinition fieldDefinitionLeft, FieldDefinition fieldDefinitionRight)
+            public ChangedEnumMember(FieldDefinition fieldDefinition)
             {
-                Name = $"{fieldDefinitionLeft.GetName()} Changed value from {fieldDefinitionLeft.Constant} to {fieldDefinitionRight.Constant}";
-                IsField = true;
+                Name = fieldDefinition.GetName();
 
-                if (fieldDefinitionRight.HasObsoleteAttribute())
+                if (fieldDefinition.HasObsoleteAttribute())
                 {
-                    var obsoleteInfo = fieldDefinitionRight.GetObsoleteInfo();
+                    var obsoleteInfo = fieldDefinition.GetObsoleteInfo();
 
                     UpgradeInstructions = obsoleteInfo.Message;
                 }
@@ -127,11 +126,7 @@
 
             public string UpgradeInstructions { get; }
 
-            public bool IsField { get; }
-
             public string Name { get; }
-
-            public bool IsMethod => !IsField;
         }
     }
 }

--- a/APIComparer.Core/TypeDiff.cs
+++ b/APIComparer.Core/TypeDiff.cs
@@ -55,6 +55,10 @@ namespace APIComparer
             return MatchingFields.Where(x => x.Left.IsPublic && x.Right.IsPublic && !x.Left.HasObsoleteAttribute() && x.Right.HasObsoleteAttribute());
         }
 
-    
+        public IEnumerable<MatchingMember<FieldDefinition>> EnumFieldsWithChangedValue()
+        {
+            //TODO: we should actually be comparing based on the enum's underlying type
+            return MatchingFields.Where(x => x.Left.IsPublic && x.Right.IsPublic && !Equals(x.Left.Constant, x.Right.Constant));
+        }
     }
 }

--- a/APIComparer.Core/TypeDiff.cs
+++ b/APIComparer.Core/TypeDiff.cs
@@ -57,7 +57,6 @@ namespace APIComparer
 
         public IEnumerable<MatchingMember<FieldDefinition>> EnumFieldsWithChangedValue()
         {
-            //TODO: we should actually be comparing based on the enum's underlying type
             return MatchingFields.Where(x => x.Left.IsPublic && x.Right.IsPublic && !Equals(x.Left.Constant, x.Right.Constant));
         }
     }

--- a/APIComparer.Core/TypeDiff.cs
+++ b/APIComparer.Core/TypeDiff.cs
@@ -55,9 +55,11 @@ namespace APIComparer
             return MatchingFields.Where(x => x.Left.IsPublic && x.Right.IsPublic && !x.Left.HasObsoleteAttribute() && x.Right.HasObsoleteAttribute());
         }
 
-        public IEnumerable<MatchingMember<FieldDefinition>> EnumFieldsWithChangedValue()
+        public IEnumerable<FieldDefinition> EnumFieldsWithChangedValue()
         {
-            return MatchingFields.Where(x => x.Left.IsPublic && x.Right.IsPublic && !Equals(x.Left.Constant, x.Right.Constant));
+            return MatchingFields
+                .Where(x => x.Left.IsPublic && x.Right.IsPublic && !Equals(x.Left.Constant, x.Right.Constant))
+                .Select(x => x.Left);
         }
     }
 }

--- a/ExampleV1/EnumWithMemberToBeChangedInNextVersion.cs
+++ b/ExampleV1/EnumWithMemberToBeChangedInNextVersion.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Example
+{
+    public enum EnumWithMemberToBeChangedInNextVersion
+    {
+        ValueToRemain = 0,
+        AnotherValueToRemain = 1,
+        ValueToBeChanged = 2,
+        [Obsolete("MemberToBeRemoved. Will be removed in version 2.0.0.", true)]
+        ObsoleteValueToBeRemoved = 3,
+        NonObsoleteValueToBeRemoved = 4
+    }
+}

--- a/ExampleV1/ExampleV1.csproj
+++ b/ExampleV1/ExampleV1.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ClassWithMembersToBeObsoletedWithWarnInNextVersion.cs" />
     <Compile Include="ClassWithPrivateMembersRemovedShouldNotBeIncluded.cs" />
     <Compile Include="ClassWithReadOnlyPropToBeRemovedInNextMajor.cs" />
+    <Compile Include="EnumWithMemberToBeChangedInNextVersion.cs" />
     <Compile Include="IMethodChangesParametersNextVersion.cs" />
     <Compile Include="InternalNextVersionClass.cs" />
     <Compile Include="MemberInternalNextVersion.cs" />

--- a/ExampleV2/EnumWithMemberToBeChangedInNextVersion.cs
+++ b/ExampleV2/EnumWithMemberToBeChangedInNextVersion.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Example
+{
+    public enum EnumWithMemberToBeChangedInNextVersion
+    {
+        ValueToRemain = 0,
+        AnotherValueToRemain = 1,
+        ValueToBeChanged = 5
+    }
+}

--- a/ExampleV2/ExampleV2.csproj
+++ b/ExampleV2/ExampleV2.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ClassWithMembersToBeObsoletedWithWarnInNextVersion.cs" />
     <Compile Include="ClassWithPrivateMembersRemovedShouldNotBeIncluded.cs" />
     <Compile Include="ClassWithReadOnlyPropToBeRemovedInNextMajor.cs" />
+    <Compile Include="EnumWithMemberToBeChangedInNextVersion.cs" />
     <Compile Include="IMethodChangesParametersNextVersion.cs" />
     <Compile Include="InternalNextVersionClass.cs" />
     <Compile Include="MemberInternalNextVersion.cs" />


### PR DESCRIPTION
I have implemented support for detecting public enum fields whose value has changed - this would typically be the result of a mistake but it is a breaking change. I have also updated the markdown generator to output an informative message regarding the change in the enum member value.
